### PR TITLE
fix proxy activation rule

### DIFF
--- a/odoo/service/wsgi_server.py
+++ b/odoo/service/wsgi_server.py
@@ -114,11 +114,7 @@ except ImportError:
     from werkzeug.contrib.fixers import ProxyFix
 
 def application(environ, start_response):
-    # FIXME: is checking for the presence of HTTP_X_FORWARDED_HOST really useful?
-    #        we're ignoring the user configuration, and that means we won't
-    #        support the standardised Forwarded header once werkzeug supports
-    #        it
-    if config['proxy_mode'] and 'HTTP_X_FORWARDED_HOST' in environ:
+    if config['proxy_mode']:
         return ProxyFix(application_unproxied)(environ, start_response)
     else:
         return application_unproxied(environ, start_response)


### PR DESCRIPTION
checking for HTTP_X_FORWARDED_HOST here is incorrect as this header is optional (per RFC7239)
upstream proxy do not need to set it up if HOST header is not being changed
second, this is as well redundant because werkzeug ProxyFix is doing much better job at verifying it
third, setting proxy_mode should be enough to use ProxyFix, proxy_mode is default False so only user need to change it intentionally

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
